### PR TITLE
Reset min-height CSS to prevent unnecessary vertical scrollbars

### DIFF
--- a/theme_overrides/css/theme_extra.css
+++ b/theme_overrides/css/theme_extra.css
@@ -38,6 +38,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .wy-nav-content-wrap {
   background-color: white;
+  min-height: auto;
 }
 
 .wy-nav-content {


### PR DESCRIPTION
@srerickson - sorry; I missed this detail in my last commit. This change to the CSS fixes a rendering issue that caused unnecessary vertical scrolling even when the content didn't fill the entire page.

### Before
<img width="1183" alt="Screen Shot 2022-01-20 at 11 20 02 AM" src="https://user-images.githubusercontent.com/639920/150379437-abe86f47-8019-42a2-ab2a-4377b0bfac97.png">

### After
<img width="1183" alt="Screen Shot 2022-01-20 at 11 19 51 AM" src="https://user-images.githubusercontent.com/639920/150379469-4725be6b-4fdb-4b02-b03c-d60126b2c0c7.png">
